### PR TITLE
Minor updates to dockerfile: pin Pillow version, use HTTPS for blender source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip3 install Pillow==4.3.0
 
 # Install Blender, so that it can perform object exports
 # directly as part of the build
-RUN curl -O http://download.blender.org/release/Blender2.74/blender-2.74-linux-glibc211-x86_64.tar.bz2 && \
+RUN curl -O https://download.blender.org/release/Blender2.74/blender-2.74-linux-glibc211-x86_64.tar.bz2 && \
   tar xf blender-2.74-linux-glibc211-x86_64.tar.bz2 && \
   mv blender-2.74-linux-glibc211-x86_64 /opt/ && \
   rm blender-2.74-linux-glibc211-x86_64.tar.bz2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 # Install the libraries that the dsgx-converter relies on
 RUN pip3 install docopt
 RUN pip3 install euclid3
-RUN pip3 install Pillow
+RUN pip3 install Pillow==4.3.0
 
 # Install Blender, so that it can perform object exports
 # directly as part of the build

--- a/shell.sh
+++ b/shell.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# run the dockerfile on this directory, which will build the project
+docker run -it --rm -v $(pwd):/source pikmin-nds bash


### PR DESCRIPTION
We should probably work to pin the rest of our software versions where possible, but for the moment, these small changes make the build succeed on all of my workstations.

Pillow is pinned to 4.3.0, which is not entirely arbitrary: it's the version installed on my desktop where the build last succeeded. Bringing it current requires python 3.5+, which isn't available in debian:jessie, which cromo/devkitarmr46 is based on.

Fixes #32 
Fixes #33 