### PR TITLE
Pin version numbers of all packages and libraries within the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip3 install Pillow==4.3.0
 
 # Install Blender, so that it can perform object exports
 # directly as part of the build
-RUN curl -O http://download.blender.org/release/Blender2.74/blender-2.74-linux-glibc211-x86_64.tar.bz2 && \
+RUN curl -O https://download.blender.org/release/Blender2.74/blender-2.74-linux-glibc211-x86_64.tar.bz2 && \
   tar xf blender-2.74-linux-glibc211-x86_64.tar.bz2 && \
   mv blender-2.74-linux-glibc211-x86_64 /opt/ && \
   rm blender-2.74-linux-glibc211-x86_64.tar.bz2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,23 @@ FROM cromo/devkitarm:r46
 # Install tools we'll use for the python build
 RUN apt-get update && \
   apt-get -y install \
-  build-essential \
-  cmake \
-  curl \
-  git \
-  golang \
-  libfreetype6 \
-  libjpeg-dev \
-  libssl-dev  \
-  libxi6 \
-  libxxf86vm1 \
-  python3 \
-  python3-pip \
-  zlib1g-dev && \
+  build-essential=11.7 \
+  cmake=3.0.2-1+deb8u1 \
+  curl=7.38.0-4+deb8u16 \
+  git=1:2.1.4-2.1+deb8u8 \
+  golang=2:1.3.3-1+deb8u2 \
+  libfreetype6=2.5.2-3+deb8u4 \
+  libjpeg-dev=1:1.3.1-12+deb8u2 \
+  libssl-dev=1.0.1t-1+deb8u12  \
+  libxi6=2:1.7.4-1+deb8u1 \
+  libxxf86vm1=1:1.1.3-1+b1 \
+  python3=3.4.2-2 \
+  python3-pip=1.5.6-5 \
+  zlib1g-dev=1:1.2.8.dfsg-2+deb8u1 && \
   rm -rf /var/lib/apt/lists/*
 
 # Install the libraries that the dsgx-converter relies on
-RUN pip3 install docopt
+RUN pip3 install docopt==0.6.2
 RUN pip3 install euclid3
 RUN pip3 install Pillow==4.3.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 # Install the libraries that the dsgx-converter relies on
 RUN pip3 install docopt
 RUN pip3 install euclid3
-RUN pip3 install Pillow
+RUN pip3 install Pillow==4.3.0
 
 # Install Blender, so that it can perform object exports
 # directly as part of the build

--- a/shell.sh
+++ b/shell.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# run the dockerfile on this directory, which will build the project
+docker run -it --rm -v $(pwd):/source pikmin-nds bash


### PR DESCRIPTION
Note that the euclid3 package isn't an intentional omission; it does not have a normal version number:

```
>>> import euclid3
>>> euclid3.__version__
'$Id: euclid.py 37 2011-08-21 22:24:05Z elfnor@gmail.com $'
```

I don't trust that stringy mess, so I've only pinned it so far as `euclid3` in the dockerfile. It also hasn't been updated since 2011, so I don't think it's in any particular danger of breaking the build with new updates. If anything we should instead be trying to factor it out in favor of something that's still being maintained.

Presuming I haven't missed anything, this fixes #35 